### PR TITLE
fix typo

### DIFF
--- a/Introduction-to-Jupyter-Notebooks/Introduction_to_Jupyter_Notebooks.ipynb
+++ b/Introduction-to-Jupyter-Notebooks/Introduction_to_Jupyter_Notebooks.ipynb
@@ -450,7 +450,7 @@
    "source": [
     "height = 14\n",
     "\n",
-    "# Reshape the hight into an array\n",
+    "# Reshape the height into an array\n",
     "new_height = np.reshape([height],(1, -1))\n",
     "\n",
     "# Pass the new height to the model so that a predicted weight can be infered\n",


### PR DESCRIPTION
minor edit for typo in Jupyter notebook "hight" - > "height"